### PR TITLE
Mount the USB filesystem with UTF-8 support

### DIFF
--- a/files/etc/ext.config
+++ b/files/etc/ext.config
@@ -2,7 +2,7 @@
 #New names
 ext_usbmount="/mnt/usb"
 ext_usbdevice="/dev/sda1"
-ext_usbmount_options="umask=0,noatime,rw"
+ext_usbmount_options="umask=0,utf8=1,noatime,rw"
 
 ext_usbdir="$ext_usbmount/external_fs"
 ext_img="$ext_usbdir/OpenWRT.img"


### PR DESCRIPTION
This is a critical component to enabling proper UTF-8 support on the PirateBox/LibraryBox filesystem.